### PR TITLE
Add incoming payments and payment_types filter to payments APIs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,8 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "lettre",
- "lightning",
+ "lightning 0.0.123",
+ "lightning-invoice",
  "log",
  "rand",
  "reqwest",
@@ -1702,12 +1703,35 @@ dependencies = [
 
 [[package]]
 name = "lightning"
+version = "0.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
+dependencies = [
+ "bitcoin 0.30.2",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning"
 version = "0.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd92d4aa159374be430c7590e169b4a6c0fb79018f5bc4ea1bffde536384db3"
 dependencies = [
  "bitcoin 0.30.2",
  "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106fdb897e69df697480f45bf0a564b425af488fb0f7407e770a770c39b19a21"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.30.2",
+ "lightning 0.0.122",
+ "num-traits",
+ "secp256k1 0.27.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,3 +50,4 @@ lettre = { version = "0.11", default-features = false, features = [
 ] }
 reqwest = { version = "0.11", features = ["json"] }
 hex = "0.4"
+lightning-invoice = "0.30.0"

--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -171,7 +171,7 @@ where
     pub states: Option<Vec<T>>,
 }
 
-fn deserialize_states<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+pub fn deserialize_states<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
 where
     D: Deserializer<'de>,
     T: DeserializeOwned + FromStr,


### PR DESCRIPTION
---

This PR updates the payments APIs to include incoming payments for both LND and CLN implementations, and adds a `payment_types` filter to list payments, enabling filtering by payment type.

#### Changes
1. **List Payments API**  
   - Now returns both outgoing and incoming payments.
   - Supports filtering results using the `payment_types` parameter.
   
2. **Get Payment Details API**  
   - Now includes details for incoming payments.
   
3. **Implementations updated**  
   - Updated both **LND** and **CLN** payment service implementations to support the above changes.
   
 #### Filters and Pagination

---

#### Filters & Pagination Examples

**Pagination Only**

```
GET /payments?page=1&per_page=10
```

**State Filter**

```
GET /payments?states=settled
GET /payments?states=failed&states=inflight
```

**Payment Type Filter**

```
GET /payments?payment_types=incoming
GET /payments?payment_types=outgoing
GET /payments?payment_types=incoming&payment_types=outgoing
```

**Amount Filter**

```
GET /payments?operator=gte&value=1000
```

**Date Range Filter**

```
GET /payments??from=2025-07-20T00:00:00Z&to=2025-07-27T23:59:59Z
```

**Combinations**

```
GET /payments?states=settled&payment_types=incoming
GET /payments?payment_types=outgoing&operator=gte&value=5000
GET /payments?payment_types=incoming&from=2025-07-20T00:00:00Z&to=2025-07-27T23:59:59Z
GET /payments?states=settled&payment_types=incoming&operator=gte&value=1000&from=2025-07-20T00:00:00Z&to=2025-07-27T23:59:59Z&page=2&per_page=20
```

---