### PR TITLE
Auto-authenticate invited users with existing node creds

### DIFF
--- a/backend/src/auth/service.rs
+++ b/backend/src/auth/service.rs
@@ -82,7 +82,7 @@ impl<'a> AuthService<'a> {
         // Check for existing node credentials and convert them to JWT format
         let credential_repo = CredentialRepository::new(self.pool);
         let node_credentials =
-            if let Some(credential) = credential_repo.get_credential_by_user_id(&user_id).await? {
+            if let Some(credential) = credential_repo.get_credential_by_account_id(&account_id).await? {
                 Some(NodeCredentials {
                     node_id: credential.node_id,
                     node_alias: credential.node_alias,

--- a/backend/src/repositories/credential_repository.rs
+++ b/backend/src/repositories/credential_repository.rs
@@ -165,6 +165,45 @@ impl<'a> CredentialRepository<'a> {
         Ok(credential)
     }
 
+    /// Retrieves credentials associated with a specific account.
+    ///
+    /// # Arguments
+    /// * `account_id` - Account ID (UUID format)
+    ///
+    /// # Returns
+    /// `Some(Credential)` if found and not deleted, `None` otherwise
+    pub async fn get_credential_by_account_id(&self, account_id: &str) -> Result<Option<Credential>> {
+        let credential = sqlx::query_as!(
+            Credential,
+            r#"
+                SELECT
+                id as "id!",
+                user_id as "user_id!",
+                account_id as "account_id!",
+                node_id as "node_id!",
+                node_alias as "node_alias!",
+                macaroon as "macaroon!",
+                tls_cert as "tls_cert!",
+                address as "address!",
+                node_type as "node_type?",
+                client_cert as "client_cert?",
+                client_key as "client_key?",
+                ca_cert as "ca_cert?",
+                is_active as "is_active!",
+                created_at as "created_at!: DateTime<Utc>",
+                updated_at as "updated_at!: DateTime<Utc>",
+                is_deleted as "is_deleted!",
+                deleted_at as "deleted_at?: DateTime<Utc>"
+                FROM credentials WHERE account_id = ? AND is_deleted = 0
+                "#,
+            account_id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+
+        Ok(credential)
+    }
+
     /// Retrieves all credentials in the system.
     ///
     /// # Returns


### PR DESCRIPTION
Invited users no longer need to add or authenticate their own node. After accepting the invite and logging in, they’re automatically authenticated using the account’s existing node credentials.