### PR TITLE
feat: split auth in two stages

### DIFF
--- a/backend/src/api/credential/handlers.rs
+++ b/backend/src/api/credential/handlers.rs
@@ -2,3 +2,63 @@
 //!
 //! These functions process requests for credential data, interact with the database
 //! or relevant services, and return credential-specific information.
+
+use crate::api::common::ApiResponse;
+use crate::repositories::credential_repository::CredentialRepository;
+use crate::utils::jwt::Claims;
+use axum::{Json, extract::Extension, http::StatusCode};
+use sqlx::SqlitePool;
+
+/// Response structure for credential status
+#[derive(Debug, serde::Serialize)]
+pub struct CredentialStatus {
+    pub has_credential: bool,
+    pub node_id: Option<String>,
+    pub node_alias: Option<String>,
+}
+
+/// Get the credential status for the authenticated user
+#[axum::debug_handler]
+pub async fn get_user_credential_status(
+    Extension(pool): Extension<SqlitePool>,
+    Extension(claims): Extension<Claims>,
+) -> Result<Json<ApiResponse<CredentialStatus>>, (StatusCode, String)> {
+    let repo = CredentialRepository::new(&pool);
+
+    match repo.get_credential_by_user_id(&claims.sub).await {
+        Ok(Some(credential)) => {
+            let status = CredentialStatus {
+                has_credential: true,
+                node_id: Some(credential.node_id),
+                node_alias: Some(credential.node_alias),
+            };
+            Ok(Json(ApiResponse::success(
+                status,
+                "Credential status retrieved successfully",
+            )))
+        }
+        Ok(None) => {
+            let status = CredentialStatus {
+                has_credential: false,
+                node_id: None,
+                node_alias: None,
+            };
+            Ok(Json(ApiResponse::success(
+                status,
+                "No credential found for user",
+            )))
+        }
+        Err(e) => {
+            tracing::error!("Failed to get credential status: {}", e);
+            let error_response = ApiResponse::<()>::error(
+                "Failed to retrieve credential status".to_string(),
+                "database_error",
+                None,
+            );
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::to_string(&error_response).unwrap(),
+            ))
+        }
+    }
+}

--- a/backend/src/api/credential/routes.rs
+++ b/backend/src/api/credential/routes.rs
@@ -2,3 +2,15 @@
 //!
 //! These routes provide endpoints for accessing and updating user-specific
 //! data beyond authentication credentials.
+
+use crate::api::credential::handlers;
+use crate::auth::middleware::jwt_auth;
+use axum::{Router, middleware, routing::get};
+
+/// Creates and returns the credential routes
+pub fn credential_routes() -> Router {
+    Router::new().route(
+        "/status",
+        get(handlers::get_user_credential_status).layer(middleware::from_fn(jwt_auth)),
+    )
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -32,6 +32,7 @@ async fn main() {
         .route("/", get(root_handler))
         .nest("/api/node", api::node::routes::node_router().await)
         .nest("/api/account", api::account::routes::account_router().await)
+        .nest("/api/credential", api::credential::routes::credential_routes())
         .nest("/auth", auth::routes::auth_router())
         .nest("/api/invite", api::invite::routes::invite_router().await)
         .nest(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2263,6 +2263,7 @@
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2273,6 +2274,7 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2323,6 +2325,7 @@
       "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.37.0",
         "@typescript-eslint/types": "8.37.0",
@@ -2840,6 +2843,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3763,6 +3767,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3937,6 +3942,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6134,6 +6140,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
       "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6215,6 +6222,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6224,6 +6232,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7000,6 +7009,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7159,6 +7169,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/app/api/credential/status/route.ts
+++ b/frontend/src/app/api/credential/status/route.ts
@@ -1,0 +1,39 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const backendUrl = process.env.BACKEND_URL || "http://localhost:3030";
+    const response = await fetch(`${backendUrl}/api/credential/status`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return NextResponse.json(
+        { error: errorData.message || "Failed to fetch credential status" },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching credential status:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/node/connect/route.ts
+++ b/frontend/src/app/api/node/connect/route.ts
@@ -1,0 +1,55 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { nodePublicKey, nodeAddress, macaroonPath, tlsCertPath } = body;
+
+    if (!nodePublicKey || !nodeAddress || !macaroonPath || !tlsCertPath) {
+      return NextResponse.json(
+        { error: "All node credentials are required" },
+        { status: 400 }
+      );
+    }
+
+    const backendUrl = process.env.BACKEND_URL || "http://localhost:3030";
+    const response = await fetch(`${backendUrl}/api/node/auth`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+      body: JSON.stringify({
+        id: nodePublicKey,
+        address: nodeAddress,
+        macaroon: macaroonPath,
+        cert: tlsCertPath,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return NextResponse.json(
+        { error: errorData.message || "Failed to connect node" },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error connecting node:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/overview/page.tsx
+++ b/frontend/src/app/overview/page.tsx
@@ -1,7 +1,12 @@
+"use client"
+
 import { AppLayout } from "@/components/app-layout"
 import { PageHeader } from "@/components/page-header"
 import { MetricCard } from "@/components/metric-card"
 import { MiniChart } from "@/components/mini-chart"
+import { ConnectNodeDialog } from "@/components/connect-node-dialog"
+import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
 import node from "../../../public/node.svg"
 
 const metricsData = [
@@ -66,9 +71,72 @@ const metricsData = [
 ]
 
 export default function Dashboard() {
+  const searchParams = useSearchParams()
+  const [hasCredential, setHasCredential] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [successMessage, setSuccessMessage] = useState("")
+  const [redirectMessage, setRedirectMessage] = useState("")
+
+  const checkCredentialStatus = async () => {
+    try {
+      const response = await fetch("/api/credential/status")
+      if (response.ok) {
+        const result = await response.json()
+        if (result.success && result.data) {
+          setHasCredential(result.data.has_credential)
+        }
+      }
+    } catch (error) {
+      console.error("Error checking credential status:", error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    checkCredentialStatus()
+    
+    // Check for redirect message
+    const message = searchParams.get("message")
+    if (message) {
+      setRedirectMessage(message)
+      setTimeout(() => setRedirectMessage(""), 8000)
+    }
+  }, [searchParams])
+
+  const handleConnectSuccess = () => {
+    setHasCredential(true)
+    setSuccessMessage("Node connected successfully!")
+    setTimeout(() => setSuccessMessage(""), 5000)
+  }
+
   return (
     <AppLayout>
       <PageHeader />
+
+      {redirectMessage && (
+        <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <p className="text-yellow-800 font-medium">{redirectMessage}</p>
+        </div>
+      )}
+
+      {!isLoading && !hasCredential && (
+        <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-blue-900">Connect Your Lightning Node</h3>
+            <p className="text-sm text-blue-700">
+              Connect your Lightning node to start monitoring your channels, payments, and invoices.
+            </p>
+          </div>
+          <ConnectNodeDialog onSuccess={handleConnectSuccess} />
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
+          <p className="text-green-800 font-medium">{successMessage}</p>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         {metricsData.map((metric, index) => (

--- a/frontend/src/components/connect-node-dialog.tsx
+++ b/frontend/src/components/connect-node-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ConnectNodeDialogProps {
+  onSuccess?: () => void;
+}
+
+export function ConnectNodeDialog({ onSuccess }: ConnectNodeDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError("");
+
+    const formData = new FormData(e.currentTarget);
+    const data = {
+      nodePublicKey: formData.get("nodePublicKey") as string,
+      nodeAddress: formData.get("nodeAddress") as string,
+      macaroonPath: formData.get("macaroonPath") as string,
+      tlsCertPath: formData.get("tlsCertPath") as string,
+    };
+
+    try {
+      const response = await fetch("/api/node/connect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        setError(result.error || "Failed to connect node");
+        return;
+      }
+
+      // Success
+      setIsOpen(false);
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      setError("An unexpected error occurred");
+      console.error("Connect node error:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button className="bg-blue-primary hover:bg-blue-600">
+          Connect Node
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[600px] font-clash-grotesk">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-semibold text-grey-dark">
+            Connect Your Lightning Node
+          </DialogTitle>
+          <DialogDescription>
+            Enter your node credentials below to connect and monitor your
+            Lightning node.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-4 py-4">
+            {error && (
+              <div className="p-3 text-sm text-red-600 bg-red-50 rounded-md border border-red-200">
+                {error}
+              </div>
+            )}
+            <div className="grid gap-2">
+              <Label htmlFor="nodePublicKey">Node Public Key</Label>
+              <Input
+                id="nodePublicKey"
+                name="nodePublicKey"
+                type="text"
+                placeholder="026c62282d38ea38daa437041b38e696f245749820343f60800c898274e8189467"
+                required
+                disabled={isLoading}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="nodeAddress">Node Address</Label>
+              <Input
+                id="nodeAddress"
+                name="nodeAddress"
+                type="text"
+                placeholder="https://192.168.122.92:10001"
+                required
+                disabled={isLoading}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="macaroonPath">Macaroon Path</Label>
+              <Input
+                id="macaroonPath"
+                name="macaroonPath"
+                type="text"
+                placeholder="/home/user/.lnd/data/chain/bitcoin/mainnet/admin.macaroon"
+                required
+                disabled={isLoading}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="tlsCertPath">TLS Certificate Path</Label>
+              <Input
+                id="tlsCertPath"
+                name="tlsCertPath"
+                type="text"
+                placeholder="/home/user/.lnd/tls.cert"
+                required
+                disabled={isLoading}
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsOpen(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="bg-blue-primary hover:bg-blue-600"
+              disabled={isLoading}
+            >
+              {isLoading ? "Connecting..." : "Connect Node"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/login-form.tsx
+++ b/frontend/src/components/login-form.tsx
@@ -32,10 +32,6 @@ export function LoginForm({
     const credentials = {
       username: formData.get("username") as string,
       password: formData.get("password") as string,
-      nodePublicKey: formData.get("nodePublicKey") as string,
-      nodeAddress: formData.get("nodeAddress") as string,
-      macaroonPath: formData.get("macaroonPath") as string,
-      tlsCertPath: formData.get("tlsCertPath") as string,
     }
 
     try {
@@ -101,58 +97,6 @@ export function LoginForm({
                   name="password"
                   type="password" 
                   placeholder="password" 
-                  required 
-                  disabled={isLoading}
-                />
-              </div>
-              <div className="grid gap-3">
-                <div className="flex items-center">
-                  <Label htmlFor="node-public-key">Node Public Key</Label>
-                </div>
-                <Input 
-                  id="node-public-key" 
-                  name="nodePublicKey"
-                  type="text" 
-                  placeholder="026c62282d38ea38daa437041b38e696f245749820343f60800c898274e8189467" 
-                  required 
-                  disabled={isLoading}
-                />
-              </div>
-              <div className="grid gap-3">
-                <div className="flex items-center">
-                  <Label htmlFor="node-address">Node Address</Label>
-                </div>
-                <Input 
-                  id="node-address" 
-                  name="nodeAddress"
-                  type="text" 
-                  placeholder="https://192.168.122.92:10001" 
-                  required 
-                  disabled={isLoading}
-                />
-              </div>
-              <div className="grid gap-3">
-                <div className="flex items-center">
-                  <Label htmlFor="macaroon-path">Macaroon Path</Label>
-                </div>
-                <Input 
-                  id="macaroon-path" 
-                  name="macaroonPath"
-                  type="text" 
-                  placeholder="/home/user/.lnd/data/chain/bitcoin/mainnet/admin.macaroon" 
-                  required 
-                  disabled={isLoading}
-                />
-              </div>
-              <div className="grid gap-3">
-                <div className="flex items-center">
-                  <Label htmlFor="tls-cert-path">TLS Certificate Path</Label>
-                </div>
-                <Input 
-                  id="tls-cert-path" 
-                  name="tlsCertPath"
-                  type="text" 
-                  placeholder="/home/user/.lnd/tls.cert" 
                   required 
                   disabled={isLoading}
                 />

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,21 +1,68 @@
-import { withAuth } from "next-auth/middleware"
+import { withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
+
+const nodeRequiredRoutes = ["/channels", "/payments", "/nodes", "/invoices"];
 
 export default withAuth(
-  function middleware(req) {
-    // Additional middleware logic can go here
+  async function middleware(req) {
+    const pathname = req.nextUrl.pathname;
+
+    const requiresNodeCredentials = nodeRequiredRoutes.some((route) =>
+      pathname.startsWith(route)
+    );
+
+    if (!requiresNodeCredentials) {
+      return NextResponse.next();
+    }
+
+    // For routes that require node credentials, check if user has them
+    try {
+      const backendUrl = process.env.BACKEND_URL || "http://localhost:3030";
+      const token = req.nextauth.token?.accessToken;
+
+      if (!token) {
+        return NextResponse.redirect(new URL("/login", req.url));
+      }
+
+      const response = await fetch(`${backendUrl}/api/credential/status`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+
+        if (!result.success || !result.data?.has_credential) {
+          const url = new URL("/overview", req.url);
+          url.searchParams.set(
+            "message",
+            "Please connect your node to access this feature"
+          );
+          return NextResponse.redirect(url);
+        }
+      }
+    } catch (error) {
+      console.error("Error checking credential status in middleware:", error);
+    }
+
+    return NextResponse.next();
   },
   {
     callbacks: {
       authorized: ({ token }) => !!token,
     },
   }
-)
+);
 
 export const config = {
   matcher: [
     "/overview/:path*",
-    "/channels/:path*", 
+    "/channels/:path*",
     "/events/:path*",
-    "/api/protected/:path*"
-  ]
-} 
+    "/profile/:path*",
+    "/payments/:path*",
+    "/nodes/:path*",
+    "/invoices/:path*",
+  ],
+};


### PR DESCRIPTION
In the current implementation, a user has to authenticate a node in the login page. This causes some issues:
1. several node credentials record in the db for one node
2. friction in login due to long auth process

This PR splits the auth process in two stages:
1. Login
2. Node connection
A user only has to login with their username and password. This allows them to access specific routes in nodegaze (profile, events, overview). The user is prompted in the UI to add/connect a node if possible. This action is only required once. Subsequent login doesn't require node authentication. 
Following this update, a new endpoint has been added `/credentials/status` which checks if the user has previously authenticated a node. If yes, we don't require node auth. If no, the user is expected to connect a node. Ideally, a user should be able to authenticate more than one node. But that is a future feature implementation.

To view node related information (payments, invoices), they need to authenticate a node. 